### PR TITLE
print/exam.php solved wrong page number

### DIFF
--- a/print/exam.php
+++ b/print/exam.php
@@ -162,9 +162,13 @@ if ($usercangrade) {
 			get_string ( "sent", "mod_emarking" ),
 			emarking_time_ago ( $exam->timecreated ) 
 	);
+
+	//get the actual count of students with the required enrolment
+	$students = emarking_get_students_count_for_printing($course->id, $exam);
+
 	$totalsheetsmessage = new stdClass();
+	$totalsheetsmessage->copies = $students + $exam->extraexams;
 	$totalsheetsmessage->originals = $exam->totalpages + $exam->extrasheets;
-	$totalsheetsmessage->copies = $exam->totalstudents + $exam->extraexams;
 	$totalsheetsmessage->totalsheets = $totalsheetsmessage->originals * $totalsheetsmessage->copies;
 	$examstable->data [] = array (
 			get_string ( 'totalpagesprint', 'mod_emarking'),


### PR DESCRIPTION
print/exam.php printed the wrong number of pages to be printed as it ignored the required enrollment requirements and just used the amount of people in the course at the moment of the eMarking creation.